### PR TITLE
change /srv directory and other new MacOS modifications

### DIFF
--- a/bevy_srv/pillar/manual_bevy_settings.sls
+++ b/bevy_srv/pillar/manual_bevy_settings.sls
@@ -19,7 +19,7 @@ wol_test_machine_ip: 192.168.88.8  # the ip address of the minion machine
 wol_test_mac: '00-1a-4b-7c-2a-b2'  # mac address of minion machine
 wol_test_sender_id: bevymaster  # Salt node id of WoL transmitter
 
-bevy_dir: '/projects/salt-bevy'  # path to salt-bevy directory tree
+bevy_dir: {{ salt['config.get']('projects_root', '/projects') ~ '/salt-bevy' }}  # path to salt-bevy directory tree
 #
 
 # the minion ID's to be put in the master's AUTOSIGN_FILE

--- a/bevy_srv/pillar/top.sls
+++ b/bevy_srv/pillar/top.sls
@@ -24,12 +24,10 @@ base:
 
   bevymaster*:
     - manual_bevy_settings
-    - bitbucket_settings
 
   'bevy:*':
     - match: grain
     - manual_bevy_settings
 
-  'win*':
-    - playready_settings
-
+#  'win*':
+#    - playready_settings

--- a/bevy_srv/salt/bevy_master/files/cloud.profiles.d/vagrant_demo_profiles.conf
+++ b/bevy_srv/salt/bevy_master/files/cloud.profiles.d/vagrant_demo_profiles.conf
@@ -6,28 +6,25 @@ vm18:   # example machine created like "vagrant up quail18"
   machine: quail18  # machine name in Vagrantfile
   provider: vagrant_demo_provider
   host: {{ salt['config.get']('vagranthost') }}
-  cwd: {{ salt['config.get']('bevy_dir') }}  # path to Vagrantfile
+  cwd: {{ salt['config.get']('cwd') }}  # path to Vagrantfile
   runas: {{ salt['config.get']('runas') }}  # owner of Vagrant boxes
   vagrant_up_timeout: 1200
 
 vm16:   # example machine created like "vagrant up quail16"
   machine: quail16  # machine name in Vagrantfile
   host: {{ salt['config.get']('vagranthost') }}
-  cwd: {{ salt['config.get']('bevy_dir') }}  # path to Vagrantfile
   runas: {{ salt['config.get']('runas') }}  # owner of Vagrant boxes
   provider: vagrant_demo_provider
 
 vm14:   # example machine created like "vagrant up quail14"
   machine: quail14  # machine name in Vagrantfile
   host: {{ salt['config.get']('vagranthost') }}
-  cwd: {{ salt['config.get']('bevy_dir') }}  # path to Vagrantfile
   runas: {{ salt['config.get']('runas') }}  # owner of Vagrant boxes
   provider: vagrant_demo_provider
 
 win16:  # example machine created like "vagrant up win16"
   machine: win16
   host: {{ salt['config.get']('vagranthost') }}
-  cwd: {{ salt['config.get']('bevy_dir') }}  # path to Vagrantfile
   runas: {{ salt['config.get']('runas') }}  # owner of Vagrant boxes
   provider: vagrant_demo_provider
   deploy: False  # provisioning is defined in Vagrantfile
@@ -36,7 +33,6 @@ gen1:   # example machine created like "GENERIC=true NODE_ADDRESS=.2.199 vagrant
   machine: gen1  # machine name in Vagrantfile
   provider: vagrant_demo_provider
   host: {{ salt['config.get']('vagranthost') }}
-  cwd: {{ salt['config.get']('bevy_dir') }}  # path to Vagrantfile
   runas: {{ salt['config.get']('runas') }}  # owner of Vagrant boxes
   vagrant_up_timeout: 1200
   env: 'GENERIC=true NODE_ADDRESS=.2.199'

--- a/bevy_srv/salt/bevy_master/files/cloud.providers.d/vagrant_demo_provider.conf
+++ b/bevy_srv/salt/bevy_master/files/cloud.providers.d/vagrant_demo_provider.conf
@@ -6,7 +6,7 @@ vagrant_demo_provider:
   username: vagrant  # pre-configured ssh username on box
   password: vagrant  # password for pre-configured ssh user
   host: {{ salt['config.get']('vagranthost') }}
-  cwd: {{ salt['config.get']('bevy_dir') }}  # path to Vagrantfile
+  cwd: {{ salt['config.get']('cwd') }}  # path to Vagrantfile
   vagrant_runas: {{ salt['config.get']('runas') }}  # owner of Vagrant boxes
   target_network: '{{ salt['config.get']('vagrant_network', '172.17.2.0/24') }}'
 

--- a/bevy_srv/salt/common.sls
+++ b/bevy_srv/salt/common.sls
@@ -64,26 +64,24 @@ debian_packages:
   pkg.installed:
     - pkgs:
       - git
-      - htop
       - nano
+      {% if grains['pythonversion'][0] == 2 %}
       - python-pip
+      {% endif %}
       - python3
       - python3-pip
       - tree
+      - virt-what
 {% endif %}
 
 {% if salt['grains.get']('os') == 'Ubuntu' %}
 ubuntu_packages:
   pkg.installed:
     - pkgs:
-      - jq
       {% if grains['osrelease'] < '18.04' %}
       - python-software-properties
       {% endif %}
-      - silversearcher-ag
-      - strace
       - vim-tiny
-      - virt-what
       {% if grains['osrelease'] < '16.04' %}
       - python-git  # fallback package if pygit2 is not found.
       {% else %}

--- a/configure_machine/macos_install_P3_salt.sh
+++ b/configure_machine/macos_install_P3_salt.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash -x
 if ! command -v python3 >/dev/null 2>&1; then
-  curl -sLo /srv/salt/python3.pkg https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg
-  installer -pkg /srv/salt/python3.pkg -target /
+  curl -sLo /tmp/python3.pkg https://www.python.org/ftp/python/3.8.0/python-3.8.0-macosx10.9.pkg
+  installer -pkg /tmp/python3.pkg -target /
 fi
 # thanks to gtmanfred for this automatic Salt installation script.
 if ! command -v salt-call >/dev/null 2>&1; then
   export SALT_VERSION="$(curl -sL https://pypi.python.org/pypi/salt/json | python -c "import sys, json; print('.'.join(sorted([x.split('.') for x in list(json.load(sys.stdin)['releases'])])[-1]))")"
-  curl -sLo /srv/salt/salt.pkg "https://repo.saltstack.com/osx/salt-$SALT_VERSION-py3-x86_64.pkg"
-  installer -pkg /srv/salt/salt.pkg -target /
+  curl -sLo /tmp/salt.pkg "https://repo.saltstack.com/osx/salt-$SALT_VERSION-py3-x86_64.pkg"
+  installer -pkg /tmp/salt.pkg -target /
 fi

--- a/configure_machine/macos_unprotect_dirs.sh
+++ b/configure_machine/macos_unprotect_dirs.sh
@@ -5,9 +5,9 @@ chflags nohidden /tmp
 mkdir -p /etc/salt/minion.d
 chown -R vagrant:staff /etc/salt
 chmod 775 /etc/salt/minion.d
-mkdir -p /srv/pillar
-chown -R vagrant:staff /srv/pillar
-chmod 775 /srv/pillar
-mkdir -p /srv/salt
-chown -R vagrant:staff /srv/salt
-chmod 775 /srv/salt
+mkdir -p /opt/saltdata/pillar
+chown -R vagrant:staff /opt/saltdata/pillar
+chmod 775 /opt/saltdata/pillar
+mkdir -p /opt/saltdata/salt
+chown -R vagrant:staff /opt/saltdata/salt
+chmod 775 /opt/saltdata/salt


### PR DESCRIPTION
Apple has thrown a major wrench in the works with the new Catalina (10.15) version of macOS.
In particular, the entire root (/) directory is now on a read only file system. This makes it rather difficult to create a new directory in /srv. After communicating with the Salt macOS slack community, I am moving the salt files to /opt/saltdata, as suggested there.

There are also a few cleanups with cloud definitions and such.
